### PR TITLE
merger: parametrize strategy for fallback field

### DIFF
--- a/tests/acceptance/test_merger_update.py
+++ b/tests/acceptance/test_merger_update.py
@@ -98,7 +98,8 @@ def _deserialize_conflict(conflict_type, path, body):
     'author_affiliation_addition',
     'author_double_match_conflict',
     'title_addition',
-    'title_change'])
+    'title_change'
+])
 def test_author_typo_scenarios(update_fixture_loader, scenario):
     root, head, update, exp, desc = update_fixture_loader.load_test(scenario)
     merger = Merger(root, head, update,


### PR DESCRIPTION
* Adds the possibility to pass a dictionary in order
to parametrize the fallback strategy for fields that
are not lists.

Signed-off-by: Riccardo Candido <riccardo.candido@gmail.com>