### PR TITLE
dict_merger: fix patch_to_conflict_set

### DIFF
--- a/json_merger/dict_merger.py
+++ b/json_merger/dict_merger.py
@@ -53,8 +53,11 @@ def _get_list_fields(obj, res, key_path=()):
 
 def patch_to_conflict_set(patch):
     """Translates a dictdiffer conflict into a json_merger one."""
-    patch_type, dotted_key, value = patch
-    key_path = tuple(k for k in dotted_key.split('.') if k)
+    patch_type, patched_key, value = patch
+    if isinstance(patched_key, list):
+        key_path = tuple(patched_key)
+    else:
+        key_path = tuple(k for k in patched_key.split('.') if k)
 
     conflicts = set()
     if patch_type == REMOVE:

--- a/tests/unit/test_merger.py
+++ b/tests/unit/test_merger.py
@@ -35,6 +35,7 @@ from json_merger.config import DictMergerOps, UnifierOps
 from json_merger.conflict import Conflict, ConflictType
 from json_merger.errors import MergeError
 from json_merger.merger import Merger
+from json_merger.dict_merger import patch_to_conflict_set
 
 
 def test_merge_bare_int_lists():
@@ -145,3 +146,27 @@ def test_merge_dict_with_keep_longest():
         m.merge()
 
     assert m.merged_root == expected
+
+
+def test_patch_to_conflict_set_handles_change_patch_with_dotted_key():
+    patch = ('change', 'a.b', ('1', '2'))
+
+    conflicts = patch_to_conflict_set(patch)
+
+    expected_conflicts = {
+        ('SET_FIELD', ('a', 'b'), '2'),
+    }
+
+    assert conflicts == expected_conflicts
+
+
+def test_patch_to_conflict_set_handles_change_patch_with_list_key():
+    patch = ('change', ['a', 0, 'b'], ('1', '2'))
+
+    conflicts = patch_to_conflict_set(patch)
+
+    expected_conflicts = {
+        ('SET_FIELD', ('a', 0, 'b'), '2'),
+    }
+
+    assert conflicts == expected_conflicts


### PR DESCRIPTION
Fix `patch_to_conflict_set` to handle list patches from
dictdiffer and move it to utils. Also, add tests.

Signed-off-by: Iuliana Voinea <iulianavoinea96@gmail.com>