### PR TITLE
dict_merger: remove duplicated patches

### DIFF
--- a/json_merger/dict_merger.py
+++ b/json_merger/dict_merger.py
@@ -36,7 +36,7 @@ from .conflict import Conflict, ConflictType
 from .errors import MergeError
 from .nothing import NOTHING
 from .utils import (
-    del_obj_at_key_path, get_dotted_key_path, get_obj_at_key_path,
+    dedupe_list, del_obj_at_key_path, get_dotted_key_path, get_obj_at_key_path,
     set_obj_at_key_path
 )
 
@@ -163,7 +163,10 @@ class SkipListsMerger(object):
             self._solve_dict_conflicts(non_list_merger, e.content)
 
         self._restore_lists()
-        self.merged_root = patch(non_list_merger.unified_patches, self.root)
+        self.merged_root = patch(
+            dedupe_list(non_list_merger.unified_patches),
+            self.root
+        )
 
     def _solve_dict_conflicts(self, non_list_merger, conflicts):
         strategies = [self._get_custom_strategy(conflict)

--- a/json_merger/utils.py
+++ b/json_merger/utils.py
@@ -102,3 +102,19 @@ def force_list(data):
     elif isinstance(data, (tuple, set)):
         return list(data)
     return data
+
+
+def dedupe_list(l):
+    """Remove duplicates from a list preserving the order.
+
+    We might be tempted to use the list(set(l)) idiom, but it doesn't preserve
+    the order, which hinders testability and does not work for lists with
+    unhashable elements.
+    """
+    result = []
+
+    for el in l:
+        if el not in result:
+            result.append(el)
+
+    return result

--- a/tests/unit/test_dict_merger.py
+++ b/tests/unit/test_dict_merger.py
@@ -915,3 +915,14 @@ def test_merge_uses_custom_rules_for_base_values():
     result = m.merged_root
 
     assert expected == result
+
+
+def test_merge_handles_duplicated_remove_patches():
+    root = {'foo': 'bar', 'baz': 'spam'}
+    head = {'foo': 'bar'}
+    update = {'foo': 'bar'}
+
+    m = SkipListsMerger(root, head, update, DictMergerOps.FALLBACK_KEEP_HEAD)
+    m.merge()
+
+    assert m.merged_root == {'foo': 'bar'}


### PR DESCRIPTION
Make `SkipListsMerger._merge_dicts` handle unified patches with
duplicates coming from `dictdiffer.Merger`.

Add util function and relevant test.

Signed-off-by: Iuliana Voinea <iulianavoinea96@gmail.com>