### PR TITLE
contrib: avoid manual merge conflicts if possible

### DIFF
--- a/tests/acceptance/test_merger_update.py
+++ b/tests/acceptance/test_merger_update.py
@@ -97,6 +97,7 @@ def _deserialize_conflict(conflict_type, path, body):
     'author_curator_collab_addition',
     'author_affiliation_addition',
     'author_double_match_conflict',
+    'author_double_match_unambiguous_fix',
     'title_addition',
     'title_change'
 ])

--- a/tests/fixtures/update_scenarios/author_double_match_unambiguous_fix/description.txt
+++ b/tests/fixtures/update_scenarios/author_double_match_unambiguous_fix/description.txt
@@ -1,0 +1,1 @@
+Two authors share the same name, but in the update they are strictly identical. Handle this without manual merge conflict.

--- a/tests/fixtures/update_scenarios/author_double_match_unambiguous_fix/expected.json
+++ b/tests/fixtures/update_scenarios/author_double_match_unambiguous_fix/expected.json
@@ -1,0 +1,47 @@
+{
+    "authors": [
+        {
+            "affiliations": [
+                {
+                    "value": "UC, Santa Barbara"
+                }
+            ],
+            "full_name": "Cox, Brian",
+            "inspire_id": "INSPIRE-42"
+        },
+        {
+            "affiliations": [
+                {
+                    "value": "UC, Berkeley"
+                }
+            ],
+            "full_name": "Cox, Brian",
+            "inspire_id": "INSPIRE-43"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://localhost:5000/api/institutions/903889"
+                    },
+                    "value": "UC, Berkeley"
+                },
+                {
+                    "record": {
+                        "$ref": "http://localhost:5000/api/institutions/903889"
+                    },
+                    "value": "LBL, Berkeley"
+                },
+                {
+                    "record": {
+                        "$ref": "http://localhost:5000/api/institutions/903889"
+                    },
+                    "value": "Santa Barbara, KITP"
+                }
+            ],
+            "curated_relation": false,
+            "full_name": "O Brien, Dara",
+            "inspire_id": "INSPIRE-00113241"
+        }
+    ]
+}

--- a/tests/fixtures/update_scenarios/author_double_match_unambiguous_fix/head.json
+++ b/tests/fixtures/update_scenarios/author_double_match_unambiguous_fix/head.json
@@ -1,0 +1,47 @@
+{
+    "authors": [
+        {
+            "affiliations": [
+                {
+                    "value": "UC, Santa Barbara"
+                }
+            ],
+            "full_name": "Cox, Brian",
+            "inspire_id": "INSPIRE-42"
+        },
+        {
+            "affiliations": [
+                {
+                    "value": "UC, Berkeley"
+                }
+            ],
+            "full_name": "Cox, Brian",
+            "inspire_id": "INSPIRE-43"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://localhost:5000/api/institutions/903889"
+                    },
+                    "value": "UC, Berkeley"
+                },
+                {
+                    "record": {
+                        "$ref": "http://localhost:5000/api/institutions/903889"
+                    },
+                    "value": "LBL, Berkeley"
+                },
+                {
+                    "record": {
+                        "$ref": "http://localhost:5000/api/institutions/903889"
+                    },
+                    "value": "Santa Barbara, KITP"
+                }
+            ],
+            "curated_relation": false,
+            "full_name": "O Brien, Dara",
+            "inspire_id": "INSPIRE-00113241"
+        }
+    ]
+}

--- a/tests/fixtures/update_scenarios/author_double_match_unambiguous_fix/root.json
+++ b/tests/fixtures/update_scenarios/author_double_match_unambiguous_fix/root.json
@@ -1,0 +1,8 @@
+{
+    "authors": [
+        {
+            "full_name": "O Brien, Dara",
+            "inspire_id": "INSPIRE-00113241"
+        }
+    ]
+}

--- a/tests/fixtures/update_scenarios/author_double_match_unambiguous_fix/update.json
+++ b/tests/fixtures/update_scenarios/author_double_match_unambiguous_fix/update.json
@@ -1,0 +1,14 @@
+{
+    "authors": [
+        {
+            "full_name": "Cox, Brian"
+        },
+        {
+            "full_name": "Cox, Brian"
+        },
+        {
+            "full_name": "O Brien, Dara",
+            "inspire_id": "INSPIRE-00113241"
+        }
+    ]
+}


### PR DESCRIPTION
This avoids manual merge conflicts in the special case where the number
of elements in the bucket are the same in head and update and all
elements of the head or the update are strictly identical.