### PR TITLE
Fix conflict on head delete

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,11 @@
 Changes
 =======
 
+Version 0.7.4
+--------------
+
+- ``KEEP_UPDATE_CONFLICT_ON_HEAD_DELETE`` doesn't take the root into account any longer.
+
 Version 0.7.3
 --------------
 

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -1,8 +1,8 @@
 ====================
- json-merger v0.7.3
+ json-merger v0.7.4
 ====================
 
-json-merger v0.7.3 was released on December 2 2020.
+json-merger v0.7.4 was released on April 1 2021.
 
 About
 -----
@@ -14,13 +14,12 @@ Python module that is able to merge json record objects.
 What's new
 ----------
 
-- Add new typoe of conflict `INSERT`.
-- `KEEP_HEAD_ENTITIES_CONFLICT_ON_NEW_UPDATE` will create INSERT conflict instead of REMOVE one.
+- ``KEEP_UPDATE_CONFLICT_ON_HEAD_DELETE`` doesn't take the root into account any longer.
 
 Installation
 ------------
 
-   $ pip install json-merger==0.7.3
+   $ pip install json-merger==0.7.4
 
 Documentation
 -------------

--- a/json_merger/__init__.py
+++ b/json_merger/__init__.py
@@ -179,21 +179,21 @@ True
 In the case in which ``root`` is represented by the latest automatic update
 of a record (e.g. crawling some metadata source),
 ``head`` by manual edits of ``root`` and ``update`` by a new automatic
-update, we might want to preserve only the entities in ``update`` but
-notify the user in case some manual addition was removed.
+update, we might want to preserve only the entities in ``update`` and
+notify the user in case some entry from ``head`` was removed.
 
   * ``UnifierOps.KEEP_UPDATE_ENTITIES_CONFLICT_ON_HEAD_DELETE``
 
 >>> root = {'badges': ['bad', 'random']}
 >>> head = {'badges': ['cool', 'nice', 'random']}
->>> update = {'badges': ['fun', 'nice', 'healthy']}
+>>> update = {'badges': ['fun', 'nice', 'random', 'healthy']}
 >>> m = Merger(root, head, update, DictMergerOps.FALLBACK_KEEP_HEAD,
 ...            UnifierOps.KEEP_UPDATE_ENTITIES_CONFLICT_ON_HEAD_DELETE)
 >>> try:
 ...     m.merge()
 ... except MergeError:
 ...     pass
->>> m.merged_root['badges'] == ['fun', 'nice', 'healthy']
+>>> m.merged_root['badges'] == ['fun', 'nice', 'random', 'healthy']
 True
 >>> m.conflicts == [Conflict(ConflictType.ADD_BACK_TO_HEAD,
 ...                          ('badges', ), 'cool')]

--- a/json_merger/config.py
+++ b/json_merger/config.py
@@ -85,5 +85,6 @@ class UnifierOps(object):
         'KEEP_HEAD_ENTITIES_CONFLICT_ON_NEW_UPDATE'
     ]
 
+
 for mode in UnifierOps.allowed_ops:
     setattr(UnifierOps, mode, mode)

--- a/json_merger/contrib/inspirehep/author_util.py
+++ b/json_merger/contrib/inspirehep/author_util.py
@@ -25,7 +25,6 @@
 from __future__ import absolute_import, print_function
 
 import re
-import unicodedata
 
 import editdistance
 import six

--- a/json_merger/dict_merger.py
+++ b/json_merger/dict_merger.py
@@ -26,7 +26,6 @@ from __future__ import absolute_import, print_function
 
 import copy
 import logging
-from itertools import chain
 
 import six
 from dictdiffer import ADD, CHANGE, REMOVE, patch
@@ -105,30 +104,30 @@ class SkipListsMerger(object):
         lists = set()
         lists.update(_get_list_fields(self.head, []))
         lists.intersection_update(_get_list_fields(self.update, []))
-        for l in lists:
-            dotted = get_dotted_key_path(l, True)
+        for list_ in lists:
+            dotted = get_dotted_key_path(list_, True)
             if dotted not in self.data_lists:
-                self.skipped_lists.add(l)
+                self.skipped_lists.add(list_)
 
     def _backup_lists(self):
         self._build_skipped_lists()
-        for l in self.skipped_lists:
-            self.list_backups[l] = (
-                get_obj_at_key_path(self.root, l),
-                get_obj_at_key_path(self.head, l),
-                get_obj_at_key_path(self.update, l))
+        for list_ in self.skipped_lists:
+            self.list_backups[list_] = (
+                get_obj_at_key_path(self.root, list_),
+                get_obj_at_key_path(self.head, list_),
+                get_obj_at_key_path(self.update, list_))
             # The root is the only one that may not be there. Head and update
             # are retrieved using list intersection.
-            del_obj_at_key_path(self.root, l, False)
-            del_obj_at_key_path(self.head, l)
-            del_obj_at_key_path(self.update, l)
+            del_obj_at_key_path(self.root, list_, False)
+            del_obj_at_key_path(self.head, list_)
+            del_obj_at_key_path(self.update, list_)
 
     def _restore_lists(self):
-        for l, (bak_r, bak_h, bak_u) in six.iteritems(self.list_backups):
+        for list_, (bak_r, bak_h, bak_u) in six.iteritems(self.list_backups):
             if bak_r is not None:
-                set_obj_at_key_path(self.root, l, bak_r)
-            set_obj_at_key_path(self.head, l, bak_h)
-            set_obj_at_key_path(self.update, l, bak_u)
+                set_obj_at_key_path(self.root, list_, bak_r)
+            set_obj_at_key_path(self.head, list_, bak_h)
+            set_obj_at_key_path(self.update, list_, bak_u)
 
     @property
     def conflicts(self):

--- a/json_merger/list_unify.py
+++ b/json_merger/list_unify.py
@@ -115,8 +115,8 @@ class ListUnifier(object):
         for node in node_order:
             self.unified.append(nodes[node])
         if (self.raise_on_head_delete and
-                self.head_stats.not_in_result_not_root_match):
-            removed = self.head_stats.not_in_result_not_root_match
+                self.head_stats.not_in_result):
+            removed = self.head_stats.not_in_result
             conflicts.extend([Conflict(ConflictType.ADD_BACK_TO_HEAD, (), r)
                               for r in removed])
         if self.raise_on_new_update:

--- a/json_merger/merger.py
+++ b/json_merger/merger.py
@@ -27,6 +27,7 @@
 from __future__ import absolute_import, print_function
 
 import copy
+import logging
 
 from .comparator import DefaultComparator
 from .dict_merger import SkipListsMerger
@@ -38,6 +39,7 @@ from .utils import (
 )
 
 PLACEHOLDER_STR = '#$PLACEHOLDER$#'
+LOGGER = logging.getLogger(__name__)
 
 
 class Merger(object):
@@ -251,6 +253,12 @@ class Merger(object):
             new_list = []
             for idx, objects in enumerate(unifier.unified):
                 root_obj, head_obj, update_obj = objects
+                LOGGER.debug(
+                    "Merging matched elements: root=%s, head=%s, update=%s",
+                    root_obj,
+                    head_obj,
+                    update_obj
+                )
                 new_obj = self._recursive_merge(root_obj, head_obj, update_obj,
                                                 absolute_key_path + (idx, ))
                 new_list.append(new_obj)
@@ -262,6 +270,8 @@ class Merger(object):
 
     def _merge_objects(self, root, head, update, key_path):
         data_lists = get_conf_set_for_key_path(self.data_lists, key_path)
+
+        LOGGER.debug("Merging non-lists at %s", key_path)
 
         object_merger = SkipListsMerger(root, head, update,
                                         self.default_dict_merge_op,
@@ -282,6 +292,13 @@ class Merger(object):
                                             self.default_list_merge_op)
         comparator_cls = self.comparators.get(dotted_key_path,
                                               DefaultComparator)
+
+        LOGGER.debug(
+            "Unifying lists at %s using operation %s and comparator %s",
+            key_path,
+            operation,
+            comparator_cls,
+        )
         list_unifier = ListUnifier(root, head, update,
                                    operation, comparator_cls)
         try:

--- a/json_merger/utils.py
+++ b/json_merger/utils.py
@@ -104,7 +104,7 @@ def force_list(data):
     return data
 
 
-def dedupe_list(l):
+def dedupe_list(list_):
     """Remove duplicates from a list preserving the order.
 
     We might be tempted to use the list(set(l)) idiom, but it doesn't preserve
@@ -113,7 +113,7 @@ def dedupe_list(l):
     """
     result = []
 
-    for el in l:
+    for el in list_:
         if el not in result:
             result.append(el)
 

--- a/json_merger/version.py
+++ b/json_merger/version.py
@@ -30,4 +30,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.7.3"
+__version__ = "0.7.4"

--- a/pytest.ini
+++ b/pytest.ini
@@ -23,4 +23,4 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 [pytest]
-addopts = --pep8 --ignore=docs --cov=json_merger --cov-report=term-missing
+addopts = --ignore=docs --cov=json_merger --cov-report=term-missing

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -24,8 +24,9 @@
 
 
 isort -rc -c -df -m5  **/*.py && \
+flake8 json_merger/ tests/ && \
 check-manifest --ignore ".travis-*" && \
 rm -rf docs/_build/ && \
 sphinx-build -qnNW docs docs/_build/html && \
-python setup.py test && \
+py.test && \
 sphinx-build -qnNW -b doctest docs docs/_build/doctest

--- a/setup.py
+++ b/setup.py
@@ -38,8 +38,8 @@ tests_require = [
     'pydocstyle>=1.0.0',
     'pytest-cache>=1.0',
     'pytest-cov>=1.8.0',
-    'pytest-pep8>=1.0.6',
-    'pytest>=2.8.0',
+    'pytest>=4.6.11',
+    'flake8>=3.9.0',
 ]
 
 contrib_require = [
@@ -61,10 +61,6 @@ extras_require = {
 extras_require['all'] = []
 for reqs in extras_require.values():
     extras_require['all'].extend(reqs)
-
-setup_requires = [
-    'pytest-runner>=2.6.2',
-]
 
 install_requires = [
     'dictdiffer>=0.6.0',
@@ -99,8 +95,6 @@ setup(
     },
     extras_require=extras_require,
     install_requires=install_requires,
-    setup_requires=setup_requires,
-    tests_require=tests_require,
     classifiers=[
         'Environment :: Web Environment',
         'Intended Audience :: Developers',

--- a/tests/unit/test_conflict.py
+++ b/tests/unit/test_conflict.py
@@ -26,7 +26,6 @@
 
 from __future__ import absolute_import, print_function
 
-import pytest
 import json
 
 from json_merger.conflict import Conflict

--- a/tests/unit/test_dict_merger.py
+++ b/tests/unit/test_dict_merger.py
@@ -28,8 +28,6 @@ from __future__ import absolute_import, print_function
 
 import pytest
 
-from dictdiffer.merge import Merger, UnresolvedConflictsException
-
 from json_merger.config import DictMergerOps
 from json_merger.conflict import Conflict, ConflictType
 from dictdiffer.conflict import Conflict as Dictdiffer_Conflict

--- a/tests/unit/test_list_align.py
+++ b/tests/unit/test_list_align.py
@@ -143,14 +143,26 @@ def test_error_on_head_delete():
     assert u.unified == [(1, 1, 1), (2, 2, 2), (NOTHING, NOTHING, 4)]
 
 
-def test_no_error_on_head_delete_from_root():
+def test_error_on_head_delete_from_root():
     root = [1, 2]
     head = [1, 2]
     update = [1, 4]
 
     u = ListUnifier(root, head, update,
                     UnifierOps.KEEP_UPDATE_ENTITIES_CONFLICT_ON_HEAD_DELETE)
-    u.unify()
+
+    with pytest.raises(MergeError) as excinfo:
+        u.unify()
+    assert len(excinfo.value.content) == 1
+
+    expect_removed = {2}
+    removed = set()
+    for conflict in excinfo.value.content:
+        assert conflict.conflict_type == ConflictType.ADD_BACK_TO_HEAD
+        assert conflict.path == ()
+        removed.add(conflict.body)
+    assert removed == expect_removed
+
     assert u.unified == [(1, 1, 1), (NOTHING, NOTHING, 4)]
 
 


### PR DESCRIPTION
* `KEEP_UPDATE_CONFLICT_ON_HEAD_DELETE` strategy was previously configured to ignore
  elements from the head also appearing in the root. This is now changed
  to ignore the root.
*ref inspirehep/inspirehep#1814
* Also adds debug logging to make investigating this kind of issues easier in the future.
* Also replaces `pep8` by `flake8`.